### PR TITLE
Fix stack smashing runtime error

### DIFF
--- a/src/paradox.c
+++ b/src/paradox.c
@@ -2864,7 +2864,7 @@ static int build_mb_block_list(pxblob_t *pxblob) {
 	size_t filesize;
 	int numblocks;
 	pxmbblockinfo_t *blocklist;
-	TMbBlockHeader2 mbblockhead;
+	TMbBlockHeader3 mbblockhead;
 
 	pxdoc = pxblob->pxdoc;
 	pxs = pxblob->mb_stream;


### PR DESCRIPTION
Fix issue when reading a database with a blob file the library crashes due to a stack smashing occurrence (when built with -fstack-protector).