### PR TITLE
Complete x64 compatibility patches from SourceForge bug #15

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,11 @@
 Version 0.6.10 (unreleased)
-	- complete remaining x64 compatibility fixes from Coolman's patches:
+	- complete remaining x64 compatibility fixes from Kenneth Porter's patches:
 	  * fix writeproc return type (size_t to ssize_t)
 	  * fix iconv_close validation for proper iconv_t handling
 	  * fix pointer arithmetic in px_head.c to avoid UB on 64-bit systems
 	  * use int32_t instead of long int for portable 64-bit compatibility
 	  * properly initialize double values
-	  (patches by Coolman, see https://sourceforge.net/p/pxlib/bugs/15/)
+	  (see https://sourceforge.net/p/pxlib/bugs/15/)
 
 Version 0.6.9
 	- use strdup() instead of _strdup() to make it compile with gcc 14

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+Version 0.6.10 (unreleased)
+	- complete remaining x64 compatibility fixes from Coolman's patches:
+	  * fix writeproc return type (size_t to ssize_t)
+	  * fix iconv_close validation for proper iconv_t handling
+	  * fix pointer arithmetic in px_head.c to avoid UB on 64-bit systems
+	  * use int32_t instead of long int for portable 64-bit compatibility
+	  * properly initialize double values
+	  (patches by Coolman, see https://sourceforge.net/p/pxlib/bugs/15/)
+
 Version 0.6.9
 	- use strdup() instead of _strdup() to make it compile with gcc 14
 

--- a/include/paradox.h.in
+++ b/include/paradox.h.in
@@ -193,7 +193,7 @@ struct px_doc {
 	int warnings;      /* Turn of/off output of warnings */
 
 	/* output function */
-	size_t (*writeproc)(pxdoc_t *p, void *data, size_t size);
+	ssize_t (*writeproc)(pxdoc_t *p, void *data, size_t size);
 
 	/* error handler function */
 	void (*errorhandler)(pxdoc_t *p, int level, const char* msg, void *data);

--- a/src/paradox.c
+++ b/src/paradox.c
@@ -30,6 +30,9 @@
 #include <fcntl.h>
 #endif
 #include <time.h>
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
 
 #ifdef WIN32
 #include <Windows.h>
@@ -2582,9 +2585,9 @@ PX_delete(pxdoc_t *pxdoc) {
 		recode_delete_request(pxdoc->in_recode_request);
 #else
 #if PX_USE_ICONV
-	if((int) pxdoc->out_iconvcd > 0)
+	if(pxdoc->out_iconvcd != (iconv_t) -1)
 		iconv_close(pxdoc->out_iconvcd);
-	if((int) pxdoc->in_iconvcd > 0)
+	if(pxdoc->in_iconvcd != (iconv_t) -1)
 		iconv_close(pxdoc->in_iconvcd);
 #endif
 #endif
@@ -3504,12 +3507,12 @@ PX_get_data_double(pxdoc_t *pxdoc, char *data, int len, double *value) {
 	memcpy(&tmp, data, 8);
 	if(tmp[0] & 0x80) {
 		tmp[0] &= 0x7f;
-	} else if(*((long int *)tmp) != 0) {
+	} else if(*((int32_t *)tmp) != 0) {
 		int k;
 		for(k=0; k<len; k++)
 			tmp[k] = ~tmp[k];
 	} else {
-		*value = 0;
+		*value = 0.0;
 		return 0;
 	}
 	*value = get_double_be(tmp); // *((double *)tmp);
@@ -3526,7 +3529,7 @@ PX_get_data_long(pxdoc_t *pxdoc, char *data, int len, long *value) {
 	memcpy(&tmp, data, 4);
 	if(tmp[0] & 0x80) {
 		tmp[0] &= 0x7f;
-	} else if(*((long int *)tmp) != 0) {
+	} else if(*((int32_t *)tmp) != 0) {
 		tmp[0] |= 0x80;
 	} else {
 		*value = 0;

--- a/src/px_head.c
+++ b/src/px_head.c
@@ -701,7 +701,7 @@ int px_add_data_to_block(pxdoc_t *pxdoc, pxhead_t *pxh, int datablocknr, int rec
 //	fprintf(stderr, "Hexdump des alten datablock headers: ");
 //	hex_dump(stderr, &datablockhead, sizeof(TDataBlock));
 //	fprintf(stderr, "\n");
-//	fprintf(stderr, "Gr��e des Datenblocks: %d\n", get_short_le_s((char *) &datablockhead.addDataSize));
+//	fprintf(stderr, "Größe des Datenblocks: %d\n", get_short_le_s((char *) &datablockhead.addDataSize));
 //	fprintf(stderr, "Datablock %d has %d records\n", datablocknr, n);
 //	fprintf(stderr, "Adding new record at postion %d in block\n", recnr);
 

--- a/src/px_head.c
+++ b/src/px_head.c
@@ -238,7 +238,6 @@ int put_px_head(pxdoc_t *pxdoc, pxhead_t *pxh, pxstream_t *pxs) {
 	int nullint = 0;
 	int i, len;
 	int sumfieldlen;   /* sum of all field name length include the 0 */
-	char *basehead;
 	int base, offset, dataheadoffset;
 	short int tmp;
 	int isindex;
@@ -247,8 +246,6 @@ int put_px_head(pxdoc_t *pxdoc, pxhead_t *pxh, pxstream_t *pxs) {
 
 	memset(&pxhead, 0, sizeof(pxhead));
 	memset(&pxdatahead, 0, sizeof(pxdatahead));
-
-	basehead = (char *) &pxhead;
 	isindex = !((pxh->px_filetype == pxfFileTypIndexDB) ||
 		        (pxh->px_filetype == pxfFileTypNonIndexDB) ||
 		        (pxh->px_filetype == pxfFileTypNonIncSecIndex) ||
@@ -288,8 +285,8 @@ int put_px_head(pxdoc_t *pxdoc, pxhead_t *pxh, pxstream_t *pxs) {
 			 * In several files it was just 12 in .DB and 17 in .PX files. */
 			put_short_le((char *)&pxhead.unknown12x13, 12);
 			put_short_le((char *)&pxhead.primaryKeyFields, pxh->px_primarykeyfields);
-			put_long_le((char *)&pxhead.primaryIndexWorkspace, (long) ((size_t)basehead-100));  /* just to set a value */
-			put_long_le((char *)&pxhead.unknownPtr1A, (long) ((size_t)basehead-500));  /* just to set a value */
+			put_long_le((char *)&pxhead.primaryIndexWorkspace, -100);  /* just to set a value */
+			put_long_le((char *)&pxhead.unknownPtr1A, -500);  /* just to set a value */
 			break;
 		case pxfFileTypPrimIndex:
 			put_short_le((char *)&pxhead.unknown12x13, 17);
@@ -322,8 +319,8 @@ int put_px_head(pxdoc_t *pxdoc, pxhead_t *pxh, pxstream_t *pxs) {
 		dataheadoffset = 0x58;
 	}
 	/* All the pointers, though we probably don't need them for a valid file */
-	put_long_le((char *)&pxhead.fldInfoPtr, (long) ((size_t)basehead+dataheadoffset));
-	put_long_le((char *)&pxhead.tableNamePtrPtr, (long) ((size_t)basehead+dataheadoffset+pxh->px_numfields*2));
+	put_long_le((char *)&pxhead.fldInfoPtr, dataheadoffset);
+	put_long_le((char *)&pxhead.tableNamePtrPtr, dataheadoffset+pxh->px_numfields*2);
 	switch(pxh->px_fileversion) {
 		case 70:
 			pxhead.fileVersionID = 0x0C;
@@ -434,7 +431,7 @@ int put_px_head(pxdoc_t *pxdoc, pxhead_t *pxh, pxstream_t *pxs) {
 	 * with numfields fields specifications (each 2 Bytes), followed
 	 * by this pointer (tableNamePtr) and numfield pointers to the
 	 * field names. */
-	put_long_le((char *)&ptr, (long) ((size_t)basehead+dataheadoffset+pxh->px_numfields*(2+4)+4));
+	put_long_le((char *)&ptr, dataheadoffset+pxh->px_numfields*(2+4)+4);
 	if(pxdoc->write(pxdoc, pxs, 4, &ptr) < 1) {
 		px_error(pxdoc, PX_RuntimeError, _("Could not write pointer to tablename."));
 		return -1;
@@ -444,7 +441,7 @@ int put_px_head(pxdoc_t *pxdoc, pxhead_t *pxh, pxstream_t *pxs) {
 	 * numfields sizeof(* Fieldname) + sizeof(* Tablename) + strlen(tablename)
 	 */
 	if(!isindex) {
-		base = (int) (size_t)basehead+dataheadoffset+pxh->px_numfields*(2+4)+4+tablenamelen;
+		base = dataheadoffset+pxh->px_numfields*(2+4)+4+tablenamelen;
 		pxf = pxh->px_fields;
 		offset = 0;
 		for(i=0; i<pxh->px_numfields; i++, pxf++) {
@@ -704,7 +701,7 @@ int px_add_data_to_block(pxdoc_t *pxdoc, pxhead_t *pxh, int datablocknr, int rec
 //	fprintf(stderr, "Hexdump des alten datablock headers: ");
 //	hex_dump(stderr, &datablockhead, sizeof(TDataBlock));
 //	fprintf(stderr, "\n");
-//	fprintf(stderr, "Größe des Datenblocks: %d\n", get_short_le_s((char *) &datablockhead.addDataSize));
+//	fprintf(stderr, "Grï¿½ï¿½e des Datenblocks: %d\n", get_short_le_s((char *) &datablockhead.addDataSize));
 //	fprintf(stderr, "Datablock %d has %d records\n", datablocknr, n);
 //	fprintf(stderr, "Adding new record at postion %d in block\n", recnr);
 


### PR DESCRIPTION
### Status

This PR applies several missing changes from the Sourceforge patch ([bug 15](https://sourceforge.net/p/pxlib/bugs/15/)) made by **[Kenneth Porter](https://sourceforge.net/u/scratchmonkey/profile/)** and reviewed by @copilot.

It is also related to https://github.com/steinm/pxlib/pull/3

- [x] Apply remaining parts of x64 patch (pxlib-0.6.8-x64.patch)
  - [x] Fix writeproc return type (size_t → ssize_t)
  - [x] Fix iconv_close validation (proper iconv_t handling)
  - [x] Fix pointer arithmetic in px_head.c (eliminate UB)
- [x] Apply putlongfix patch (pxlib-0.6.8-putlongfix.patch)
  - [x] Fix long int → int32_t casts in paradox.c
  - [x] Fix double initialization to 0.0
- [x] Add stdint.h with proper guards

**pxlib-0.6.8-x64.patch (64-bit compatibility):**
- ✅ Most ssize_t changes - PREVIOUSLY APPLIED in v0.6.8
- ❌ writeproc return type - **APPLIED IN THIS PR**
- ❌ iconv_close validation - **APPLIED IN THIS PR**
- ❌ Pointer arithmetic fixes - **APPLIED IN THIS PR**
- ✅ Unused variable removal - PREVIOUSLY APPLIED in v0.6.8
- ✅ Pointer format strings - PREVIOUSLY APPLIED in v0.6.8

**pxlib-0.6.8-putlongfix.patch (integer portability):**
- ❌ long int → int32_t casts - **APPLIED IN THIS PR**
- ❌ double = 0.0 fix - **APPLIED IN THIS PR**

### Critical Issues Fixed:

1. **Memory Safety** - Incorrect iconv_close could cause crashes on 64-bit systems
2. **Undefined Behavior** - Pointer-to-integer conversions caused unpredictable behavior
3. **Data Corruption** - Wrong integer sizes could corrupt data when reading Paradox files on 64-bit Linux
4. **Error Handling** - writeproc couldn't properly signal errors with unsigned return type

### Platform-Specific Problems:

| Platform | long int size | Issue |
|----------|---------------|-------|
| 32-bit Linux/Windows | 4 bytes | ✓ Works (accidentally) |
| 64-bit Windows | 4 bytes | ✓ Works |
| 64-bit Linux/Unix | 8 bytes | ✗ BROKEN without patches |
