### PR TITLE
cmake: use find_package(Iconv) for modern iconv detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,23 +36,10 @@ check_include_file("gsf/gsf-input-stdio.h" HAVE_GSF_GSFINPUTSTDIO_H)
 include(CheckFunctionExists)
 include(CheckLibraryExists)
 
-# Check for iconv
-if(HAVE_ICONV_H)
-    # First check if iconv is in libc
-    check_function_exists(iconv ICONV_IN_LIBC)
-    
-    if(NOT ICONV_IN_LIBC)
-        # Check if iconv is in a separate library
-        check_library_exists(iconv iconv "" HAVE_ICONV_LIB)
-        if(HAVE_ICONV_LIB)
-            set(ICONV_LIBRARIES iconv)
-        endif()
-    endif()
-    
-    if(ICONV_IN_LIBC OR HAVE_ICONV_LIB)
-        set(HAVE_ICONV 1)
-    endif()
-endif()
+# Check for iconv via CMake's modern Iconv module (CMake 3.11+)
+find_package(Iconv REQUIRED)
+set(HAVE_ICONV 1)
+set(ICONV_LIBRARIES Iconv::Iconv)
 
 # Endianess
 include(TestBigEndian)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,11 @@ include(CheckFunctionExists)
 include(CheckLibraryExists)
 
 # Check for iconv via CMake's modern Iconv module (CMake 3.11+)
-find_package(Iconv REQUIRED)
-set(HAVE_ICONV 1)
-set(ICONV_LIBRARIES Iconv::Iconv)
+find_package(Iconv)
+if(Iconv_FOUND)
+    set(HAVE_ICONV 1)
+    set(ICONV_LIBRARIES Iconv::Iconv)
+endif()
 
 # Endianess
 include(TestBigEndian)


### PR DESCRIPTION
## Problem

`PX_set_targetencoding()` is silently a no-op on Windows when pxlib is built via vcpkg, because the iconv detection in `CMakeLists.txt` doesn't recognize vcpkg's `libiconv`.

The legacy detection pattern is:

```cmake
check_include_file("iconv.h" HAVE_ICONV_H)
...
if(HAVE_ICONV_H)
    check_function_exists(iconv ICONV_IN_LIBC)
    if(NOT ICONV_IN_LIBC)
        check_library_exists(iconv iconv "" HAVE_ICONV_LIB)
        ...
```

On Windows with vcpkg's libiconv, the installed `iconv.lib` doesn't expose a bare `iconv` C symbol findable by `check_library_exists` — it exports `libiconv`, `iconv_open`, etc. So `HAVE_ICONV_LIB` stays undefined, `HAVE_ICONV` is never set, and `PX_HAVE_ICONV` (line 62) ends up 0. The generated `paradox.h` gets `#define PX_USE_ICONV 0`, and pxlib's `PX_set_targetencoding()` API becomes a no-op.

This is reproducible by building pxlib with vcpkg's libiconv on the include/lib path. Reading any Paradox `.DB` whose codepage is CP437 / CP850 returns raw single-byte data instead of the user-requested target encoding.

## Fix

Replace the legacy block with CMake's built-in `FindIconv` module:

```cmake
find_package(Iconv)
if(Iconv_FOUND)
    set(HAVE_ICONV 1)
    set(ICONV_LIBRARIES Iconv::Iconv)
endif()
```

`FindIconv` ships with CMake since 3.11. This project already requires 3.12 (line 1), so no minimum-version bump is needed. The module handles all platforms uniformly: glibc-iconv on Linux, system iconv on macOS, libiconv on Windows (vcpkg, msys2, etc.).

The downstream `target_link_libraries(pxlib PRIVATE ${ICONV_LIBRARIES})` call (line 152) keeps working unchanged — it now links against the `Iconv::Iconv` imported target.

## Why optional (not `REQUIRED`)

The original detection was non-fatal: if iconv wasn't available, the build proceeded with `PX_USE_ICONV=0` and `PX_set_targetencoding()` silently became a no-op. This change preserves that contract — `find_package(Iconv)` without `REQUIRED`, gated by `if(Iconv_FOUND)` — so environments without iconv (e.g. the `windows-latest` GitHub Actions runner used by this project's CI, which has no iconv installed) still build successfully. Consumers that need iconv (vcpkg, distros, etc.) declare it as a dependency, which guarantees `Iconv_FOUND` for them.

## Tested on

- Windows 11 Pro (build 10.0.26200) + MSVC 14.44.35207 (Visual Studio 2022 Community) + vcpkg `libiconv` 1.18 → `PX_USE_ICONV` flips from 0 to 1; `iconv-2.dll` is correctly linked into `pxlib.dll` (verified via the imported-DLL list).
- This PR's GitHub Actions: build-windows / build-linux (gcc, clang) / build-macos all green.

The vcpkg port for pxlib will pick this up to drop a downstream-only patch once merged: a companion PR is being opened against [microsoft/vcpkg](https://github.com/microsoft/vcpkg) that includes the same change as a port-local patch in the meantime.
