### PR TITLE
Fix iconv handle sentinel check (> 0 -> != (iconv_t) -1)

### DIFF
--- a/src/px_encode.c
+++ b/src/px_encode.c
@@ -46,7 +46,7 @@ int px_set_targetencoding(pxdoc_t *pxdoc) {
 #else
 #if PX_USE_ICONV
 		sprintf(buffer, "CP%d", pxdoc->px_head->px_doscodepage);
-		if(pxdoc->out_iconvcd > 0)
+		if(pxdoc->out_iconvcd != (iconv_t) -1)
 			iconv_close(pxdoc->out_iconvcd);
 		if((iconv_t)(-1) == (pxdoc->out_iconvcd = iconv_open(pxdoc->targetencoding, buffer))) {
 			return -1;
@@ -73,7 +73,7 @@ int px_set_inputencoding(pxdoc_t *pxdoc) {
 #else
 #if PX_USE_ICONV
 		sprintf(buffer, "CP%d", pxdoc->px_head->px_doscodepage);
-		if(pxdoc->in_iconvcd > 0)
+		if(pxdoc->in_iconvcd != (iconv_t) -1)
 			iconv_close(pxdoc->in_iconvcd);
 		if((iconv_t)(-1) == (pxdoc->in_iconvcd = iconv_open(buffer, pxdoc->inputencoding))) {
 			return -1;


### PR DESCRIPTION
## Problem

`pxlib` initialises `out_iconvcd` and `in_iconvcd` to `(iconv_t)-1` as a
"no open handle" sentinel (see `paradox.c`). On Windows, `iconv_t` is a
pointer-sized type (`void*` / `size_t`), so `(iconv_t)-1` evaluates to
`0xFFFFFFFFFFFFFFFF`. That value is `> 0`, so the existing guard in
`px_set_targetencoding` and `px_set_inputencoding`:

```c
if(pxdoc->out_iconvcd > 0)
    iconv_close(pxdoc->out_iconvcd);
```

incorrectly passes on the **very first** call — before any real iconv handle
has been opened. `iconv_close((iconv_t)-1)` → `free(0xFFFFFFFF…)` →
`STATUS_HEAP_CORRUPTION` in the Windows debug heap.

The bug does not manifest on Linux/macOS because there `(iconv_t)-1` is
negative and therefore not `> 0`.

## Fix

Replace `> 0` with `!= (iconv_t) -1` in both `px_set_targetencoding` and
`px_set_inputencoding` in `src/px_encode.c`. This is exactly the check that
`paradox.c` already uses in its own cleanup path — this PR makes
`px_encode.c` consistent with that convention.

## Context

Discovered while testing #14 on Windows (enabling iconv via
`find_package(Iconv)`). After enabling iconv, every first call to
`PX_set_targetencoding` triggered the heap corruption breakpoint.