### PR TITLE
Apply targetencoding to memo BLObs in PX_retrieve_record

### DIFF
--- a/src/paradox.c
+++ b/src/paradox.c
@@ -2039,6 +2039,38 @@ PX_retrieve_record(pxdoc_t *pxdoc, int recno) {
 						ret = PX_get_data_blob(pxdoc, &data[offset], pxf->px_flen, &mod_nr, &size, &blobdata);
 					if(ret > 0) {
 						if(blobdata) {
+#if PX_USE_ICONV
+							/* Memo BLObs are text in the DB's source codepage;
+							 * convert to targetencoding here, mirroring
+							 * PX_get_data_alpha. Other blob types
+							 * (pxfBLOb, pxfGraphic, pxfOLE) stay binary. */
+							if((pxf->px_ftype == pxfMemoBLOb || pxf->px_ftype == pxfFmtMemoBLOb)
+							   && pxdoc->targetencoding != NULL
+							   && pxdoc->out_iconvcd != (iconv_t)-1 && size > 0) {
+								char *obuf, *iptr = blobdata, *optr;
+								size_t olen = 2*(size_t)size + 1, ilen = (size_t)size;
+								int res;
+								optr = obuf = (char *) malloc(olen);
+								if(obuf != NULL) {
+									res = (int)iconv(pxdoc->out_iconvcd, &iptr, &ilen, &optr, &olen);
+									if(0 <= res) {
+										char *nb;
+										*optr = '\0';
+										olen = optr - obuf;
+										nb = (char *) pxdoc->malloc(pxdoc, olen+1,
+											_("Allocate memory for re-encoded memo data."));
+										if(nb) {
+											memcpy(nb, obuf, olen);
+											nb[olen] = '\0';
+											pxdoc->free(pxdoc, blobdata);
+											blobdata = nb;
+											size = (int)olen;
+										}
+									}
+									free(obuf);
+								}
+							}
+#endif
 							dataptr[i]->value.str.val = blobdata;
 							dataptr[i]->value.str.len = size;
 						} else {


### PR DESCRIPTION
## Problem

`PX_retrieve_record` has a combined `case` arm covering `pxfGraphic`, `pxfBLOb`, `pxfFmtMemoBLOb`, `pxfMemoBLOb`, and `pxfOLE`. When `targetencoding` is set, the alpha-field path (`PX_get_data_alpha`) correctly runs field bytes through `pxdoc->out_iconvcd` to produce output in the requested encoding. The memo-blob arm does not — it returns whatever bytes `PX_get_data_blob` produced, which are in the database's source codepage.

Any downstream consumer that expects `targetencoding` to apply uniformly to all text fields receives raw source-codepage bytes for memo fields and correctly-encoded bytes for everything else, leading to mojibake or invalid-sequence errors in memo text.

## Fix

Add a `#if PX_USE_ICONV` block inside the `if(blobdata)` branch, gated on `pxfMemoBLOb || pxfFmtMemoBLOb`, that transcodes the blob data through `pxdoc->out_iconvcd` before storing it in `dataptr[i]->value.str.val`. Binary blob types (`pxfBLOb`, `pxfGraphic`, `pxfOLE`) are left untouched.

The implementation mirrors `PX_get_data_alpha` in buffer sizing (`olen = 2 * size + 1`, covering worst-case 1→2 byte expansion for single-byte → UTF-8) and pointer conventions. Three intentional differences from the alpha path:

- **Type guard** on `pxf->px_ftype`: binary and memo blobs share one case arm; the guard keeps binary types byte-for-byte.
- **Handle check** (`out_iconvcd != (iconv_t)-1`): the case arm is entered regardless of whether `targetencoding` is set; we must verify the handle is open before calling `iconv`.
- **`pxdoc->free(blobdata)`** before replacing: `PX_get_data_blob` allocates via `pxdoc->malloc`; unlike `PX_get_data_alpha` which receives a pointer into the record buffer, we own the allocation and must free it.

On iconv failure or allocation failure the original bytes are returned unchanged — no existing consumer regresses. Behavior is entirely unchanged when `targetencoding` is NULL.

## Context

Discovered while reading a CP437 Paradox database and writing memo field values into DICOM tags (`SpecificCharacterSet = ISO_IR 192`). The CP437 byte `0x94` (`ö`) was passed verbatim to a UTF-8 decoder, which produced the Unicode replacement character (U+FFFD) because `0x94` is not valid UTF-8. Alpha fields in the same database round-tripped correctly via the existing `PX_get_data_alpha` iconv path; only memo BLObs were affected.